### PR TITLE
Local parts with dots and rare local part falsey checks

### DIFF
--- a/src/Email.elm
+++ b/src/Email.elm
@@ -86,28 +86,23 @@ localParser =
         |> andThen checkLocal
 
 
-domainPart : Parser String
-domainPart =
+domainParser : Parser String
+domainParser =
     let
         checkLen s =
             if String.isEmpty s then
+                problem "domain is empty"
+
+            else if not <| String.contains "." s then
                 problem "domain is not valid"
 
             else
                 succeed s
     in
     chompWhile
-        (\c -> Char.isAlphaNum c || c == '-')
+        (\c -> Char.isAlphaNum c || c == '-' || c == '.')
         |> getChompedString
         |> andThen checkLen
-
-
-domainParser : Parser String
-domainParser =
-    succeed (\pre suf -> pre ++ "." ++ suf)
-        |= domainPart
-        |. symbol "."
-        |= domainPart
 
 
 emailParser : Parser EmailAddress

--- a/tests/EmailTest.elm
+++ b/tests/EmailTest.elm
@@ -23,6 +23,10 @@ suite =
                 \_ ->
                     isValid "hello@world.com"
                         |> Expect.equal True
+            , test "valid email, multiple dots in domain parts" <|
+                \_ ->
+                    isValid "user@one.two.three"
+                        |> Expect.equal True
             , test "invalid char in local part" <|
                 \_ ->
                     isValid "he^llo@world.com"

--- a/tests/EmailTest.elm
+++ b/tests/EmailTest.elm
@@ -23,6 +23,14 @@ suite =
                 \_ ->
                     isValid "hello@world.com"
                         |> Expect.equal True
+            , test "valid email - dot in local part" <|
+                \_ ->
+                    isValid "hello.world@world.com"
+                        |> Expect.equal True
+            , test "valid email - multiple dots in local part" <|
+                \_ ->
+                    isValid "h.e.l.l.o@world.com"
+                        |> Expect.equal True
             , test "valid email, multiple dots in domain parts" <|
                 \_ ->
                     isValid "user@one.two.three"
@@ -46,6 +54,24 @@ suite =
             , test "missing local" <|
                 \_ ->
                     isValid "@world.com"
+                        |> Expect.equal False
+            ]
+        , describe "obscure email variations (these are valid if quoted, but RFC 5321 warns against it and this is accepted as a bad idea)"
+            [ test "local part is whitespace - not quoted" <|
+                \_ ->
+                    isValid " @example.org"
+                        |> Expect.equal False
+            , test "local part has 2 consecutive dots" <|
+                \_ ->
+                    isValid "john..doe@example.org"
+                        |> Expect.equal False
+            , test "local part starts with dot" <|
+                \_ ->
+                    isValid ".john@example.org"
+                        |> Expect.equal False
+            , test "local part ends with dot" <|
+                \_ ->
+                    isValid "john.@example.org"
                         |> Expect.equal False
             ]
         , describe "toString"


### PR DESCRIPTION
Closes #1 

* Allows dot to be included in local part
* Does not allow local part to start or end with dot
* Does not allow local part to have consecutive dots
* Does not allow whitespace in local part, even if quoted.
* Adds tests for these cases.

The special cases for local parts can technically be valid if quoted, but RFC 5321 warns against it and this is accepted as a bad idea.

From [wikipedia](https://en.wikipedia.org/wiki/Email_address#Local-part)

> A local part is either a Dot-string or a Quoted-string; it cannot be a combination. Quoted strings and characters however, are not commonly used.[citation needed] RFC 5321 also warns that "a host that expects to receive mail SHOULD avoid defining mailboxes where the Local-part requires (or uses) the Quoted-string form". 

While the above quote has a note to add a citation about recommending against this, I agree that allowing these odd quoted cases are not what we see IRL on email servers. If I'm wrong about that, let's find examples and get this updated. For now, this solves the original issue.